### PR TITLE
fix warnings when running the frontend npm

### DIFF
--- a/rpi-eventhub/frontend/index.html
+++ b/rpi-eventhub/frontend/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./public/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="An all-in-one platform for RPI students and staff to effortlessly create, advertise, and explore diverse campus events."
     />
-    <link rel="apple-touch-icon" href="./public/android-chrome-192x192.png" />
-    <link rel="manifest" href="./public/manifest.json" />
+    <link rel="apple-touch-icon" href="./android-chrome-192x192.png" />
+    <link rel="manifest" href="./manifest.json" />
     <title>EventHub</title>
         <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-YTNJC09YQ1"></script>


### PR DESCRIPTION
```
Files in the public directory are served at the root path.
Instead of /public/manifest.json, use /manifest.json.
```

This change fixes the above warning on the frontend when a user first requests the page, clearing up visual feedback for actually important logs.

Has been tested already.